### PR TITLE
Fix TypeScript compatibility for NodeConnectionType

### DIFF
--- a/nodes/Valyu/Valyu.node.ts
+++ b/nodes/Valyu/Valyu.node.ts
@@ -1,3 +1,4 @@
+import type { NodeConnectionType } from 'n8n-workflow';
 import {
 	IExecuteFunctions,
 	INodeExecutionData,
@@ -316,8 +317,8 @@ export class Valyu implements INodeType {
 		subtitle: '={{$parameter["operation"]}}',
 		description: 'Search, Extract, Answer, and Deep Research with Valyu AI',
 		defaults: { name: 'Valyu' },
-		inputs: ['main'],
-		outputs: ['main'],
+		inputs: ['main' as NodeConnectionType],
+		outputs: ['main' as NodeConnectionType],
 		credentials: [{ name: 'valyuApi', required: true }],
 		properties: [
 			// ============ OPERATION SELECTOR ============

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-valyu",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "n8n node for Valyu - Search, Extract, Answer, and Deep Research APIs for AI applications.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
- Use type import with string assertion for cross-version TypeScript compatibility
- Fixes CI build failure due to TypeScript version differences
- Bump version to 0.2.2

## Test plan
- [x] Lint passes
- [x] Build passes locally
- [ ] CI build passes