### PR TITLE
Fix build: update valyu-js dependency to ^2.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "n8n-nodes-valyu",
-  "version": "0.1.2",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-valyu",
-      "version": "0.1.2",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
-        "valyu-js": "^2.2.3"
+        "valyu-js": "^2.5.3"
       },
       "devDependencies": {
         "@typescript-eslint/parser": "~8.32.0",
@@ -4683,9 +4683,9 @@
       }
     },
     "node_modules/valyu-js": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/valyu-js/-/valyu-js-2.2.3.tgz",
-      "integrity": "sha512-pAUmlF2Te86cfDnl6xAqBubgEMSW9kGOjgmvP7ArHRoH61175zus3vnZ3fHbU5kl1pNsJoYdd0y3CwXYnHnoKA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/valyu-js/-/valyu-js-2.5.3.tgz",
+      "integrity": "sha512-M7lQnCeAlj7LBOdzzlF8Zriqe43+ROa21vHkuc+xWTfH0nY3XenA8jkS+JAlZwnRkGf2Paw1b/3XaLGMSVOz9Q==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-valyu",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "n8n node for Valyu - Search, Extract, Answer, and Deep Research APIs for AI applications.",
   "keywords": [
     "n8n-community-node-package",
@@ -57,6 +57,6 @@
     "n8n-workflow": "*"
   },
   "dependencies": {
-    "valyu-js": "^2.2.3"
+    "valyu-js": "^2.5.3"
   }
 }


### PR DESCRIPTION
## Summary
- Update valyu-js dependency from ^2.2.3 to ^2.5.3 (includes max mode type)
- Fixes TypeScript build failure from `"max"` not being in `DeepResearchMode`
- Bump version to 0.2.5